### PR TITLE
fix: assign policy to the 'others' category

### DIFF
--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -4,3 +4,4 @@ version=${project.version}
 description=${project.description}
 class=io.gravitee.policy.circuitbreaker.CircuitBreakerPolicy
 type=policy
+category=others


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7636

**Description**

feat: assign policy to the 'others' category
That will make the policy appear in the right category on console, instead of "no category".

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1-fix-assignCategory-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-circuit-breaker/1.1.1-fix-assignCategory-SNAPSHOT/gravitee-policy-circuit-breaker-1.1.1-fix-assignCategory-SNAPSHOT.zip)
  <!-- Version placeholder end -->
