### PR TITLE
test: test policy with APIM Gateway SDK

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@2.1
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -31,19 +31,20 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>20.2</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.15.3</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.5.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.15.4</gravitee-common.version>
+        <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <resilience4j-circuitbreaker.version>1.3.1</resilience4j-circuitbreaker.version>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
     </properties>
 
     <dependencyManagement>
@@ -116,9 +117,22 @@
 
         <!-- Test scope -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>io.gravitee.apim.gateway</groupId>
+            <artifactId>gravitee-apim-gateway-tests-sdk</artifactId>
+            <version>${gravitee-apim-gateway-tests-sdk.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/gravitee/policy/circuitbreaker/CircuitBreakerPolicy.java
+++ b/src/main/java/io/gravitee/policy/circuitbreaker/CircuitBreakerPolicy.java
@@ -35,8 +35,6 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.gravitee.policy.circuitbreaker.configuration.CircuitBreakerPolicyConfiguration;
 import java.time.Duration;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -46,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 public class CircuitBreakerPolicy {
 
     private static final String CIRCUIT_BREAKER_OPEN_STATE = "CIRCUIT_BREAKER_OPEN_STATE";
-    private static final String CIRCUIT_BREAKER_OPEN_STATE_MESSAGE = "Service temporarily unavailable";
+    static final String CIRCUIT_BREAKER_OPEN_STATE_MESSAGE = "Service temporarily unavailable";
 
     private final CircuitBreakerRegistry registry = CircuitBreakerRegistry.ofDefaults();
 

--- a/src/test/java/io/gravitee/policy/circuitbreaker/CircuitBreakerPolicyIntegrationTest.java
+++ b/src/test/java/io/gravitee/policy/circuitbreaker/CircuitBreakerPolicyIntegrationTest.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.circuitbreaker;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.extension.responsetemplating.ResponseTemplateTransformer;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.gravitee.apim.gateway.tests.sdk.AbstractPolicyTest;
+import io.gravitee.apim.gateway.tests.sdk.annotations.DeployApi;
+import io.gravitee.apim.gateway.tests.sdk.annotations.GatewayTest;
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.definition.model.Api;
+import io.gravitee.policy.circuitbreaker.configuration.CircuitBreakerPolicyConfiguration;
+import io.reactivex.observers.TestObserver;
+import io.vertx.reactivex.core.buffer.Buffer;
+import io.vertx.reactivex.ext.web.client.HttpResponse;
+import io.vertx.reactivex.ext.web.client.WebClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Circuit breaker internal behavior is based on a registry with {@link io.gravitee.gateway.api.ExecutionContext#ATTR_RESOLVED_PATH} as key.
+ *
+ * This means that the key is the path of the resolved flow for the call.
+ * To avoid flakiness when running tests, it is preferable to deploy the API once per test, to avoid having one and only one instance of the policy and so, to avoid mixing circuit breaking statistics across tests.
+ * @author Yann TAVERNIER (yann.tavernier at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@GatewayTest
+class CircuitBreakerPolicyIntegrationTest extends AbstractPolicyTest<CircuitBreakerPolicy, CircuitBreakerPolicyConfiguration> {
+
+    public static final String LOCALHOST = "localhost:";
+    public static final String REDIRECT_URL = LOCALHOST + "8089";
+
+    @RegisterExtension
+    static WireMockExtension redirectServer = WireMockExtension.newInstance().options(wireMockConfig().dynamicPort()).build();
+
+    @Override
+    protected void configureWireMock(WireMockConfiguration configuration) {
+        configuration.extensions(new ResponseTemplateTransformer(true));
+    }
+
+    @Override
+    public void configureApi(Api api) {
+        if (api.getId().equals("my-api-redirect")) {
+            api
+                .getFlows()
+                .forEach(flow -> {
+                    flow
+                        .getPre()
+                        .stream()
+                        .filter(step -> policyName().equals(step.getPolicy()))
+                        .forEach(step ->
+                            step.setConfiguration(step.getConfiguration().replace(REDIRECT_URL, LOCALHOST + redirectServer.getPort()))
+                        );
+                });
+        }
+    }
+
+    @Test
+    @DeployApi("/apis/circuit-breaker.json")
+    @DisplayName("Should open circuit when too many slow calls")
+    void shouldOpenCircuitWhenSlowCalls(WebClient client) {
+        wiremock.stubFor(get("/endpoint/my_team").willReturn(ok("response from backend").withFixedDelay(750)));
+
+        TestObserver<HttpResponse<Buffer>> obs = client.get("/test/my_team").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(200);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.stubFor(get("/endpoint/my_team").willReturn(ok("response from backend").withFixedDelay(750)));
+
+        obs = client.get("/test/my_team").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(HttpStatusCode.SERVICE_UNAVAILABLE_503);
+                assertThat(response.statusMessage()).isEqualToIgnoringCase("Service Unavailable");
+                assertThat(response.bodyAsString()).isEqualTo(CircuitBreakerPolicy.CIRCUIT_BREAKER_OPEN_STATE_MESSAGE);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint/my_team")));
+    }
+
+    @Test
+    @DeployApi("/apis/circuit-breaker.json")
+    @DisplayName("Should open circuit when too many failures")
+    void shouldOpenCircuitWhenFailures(WebClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(505).withBody("response from backend")));
+
+        TestObserver<HttpResponse<Buffer>> obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(505);
+                assertThat(response.bodyAsString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(505).withBody("response from backend")));
+
+        obs = client.get("/test").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(HttpStatusCode.SERVICE_UNAVAILABLE_503);
+                assertThat(response.statusMessage()).isEqualToIgnoringCase("Service Unavailable");
+                assertThat(response.bodyAsString()).isEqualTo(CircuitBreakerPolicy.CIRCUIT_BREAKER_OPEN_STATE_MESSAGE);
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+    }
+
+    @Test
+    @DeployApi("/apis/circuit-breaker-redirect.json")
+    @DisplayName("Should redirect to URL if opened circuit due to too many failures")
+    void shouldRedirectWhenCircuitOpen(WebClient client) {
+        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(505).withBody("response from backend")));
+
+        TestObserver<HttpResponse<Buffer>> obs = client.get("/circuit-redirect").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(505);
+                assertThat(response.bodyAsString()).isEqualTo("response from backend");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.stubFor(get("/endpoint").willReturn(aResponse().withStatus(505).withBody("response from backend")));
+        redirectServer.stubFor(get("/redirection").willReturn(ok("redirection went well")));
+
+        obs = client.get("/circuit-redirect").rxSend().test();
+
+        awaitTerminalEvent(obs);
+        obs
+            .assertComplete()
+            .assertValue(response -> {
+                assertThat(response.statusCode()).isEqualTo(HttpStatusCode.OK_200);
+                assertThat(response.bodyAsString()).isEqualTo("redirection went well");
+                return true;
+            })
+            .assertNoErrors();
+
+        wiremock.verify(1, getRequestedFor(urlPathEqualTo("/endpoint")));
+        redirectServer.verify(1, getRequestedFor(urlPathEqualTo("/redirection")));
+    }
+}

--- a/src/test/resources/apis/circuit-breaker-redirect.json
+++ b/src/test/resources/apis/circuit-breaker-redirect.json
@@ -1,0 +1,48 @@
+{
+  "id": "my-api-redirect",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/circuit-redirect",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Circuit breaker",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-circuit-breaker",
+          "configuration": {
+            "failureRateThreshold": 1,
+            "slowCallRateThreshold": 10,
+            "slowCallDurationThreshold": 500,
+            "windowSize": 2,
+            "waitDurationInOpenState": 50000,
+            "redirectToURL": "http://localhost:8089/redirection"
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}

--- a/src/test/resources/apis/circuit-breaker.json
+++ b/src/test/resources/apis/circuit-breaker.json
@@ -1,0 +1,48 @@
+{
+  "id": "my-api",
+  "name": "my-api",
+  "gravitee": "2.0.0",
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://localhost:8080/endpoint",
+        "http": {
+          "connectTimeout": 3000,
+          "readTimeout": 60000
+        }
+      }
+    ]
+  },
+  "flows": [
+    {
+      "name": "flow-1",
+      "methods": [
+        "GET"
+      ],
+      "enabled": true,
+      "path-operator": {
+        "path": "/",
+        "operator": "STARTS_WITH"
+      },
+      "pre": [
+        {
+          "name": "Circuit breaker",
+          "description": "",
+          "enabled": true,
+          "policy": "policy-circuit-breaker",
+          "configuration": {
+            "failureRateThreshold": 1,
+            "slowCallRateThreshold": 10,
+            "slowCallDurationThreshold": 500,
+            "windowSize": 2,
+            "waitDurationInOpenState": 50000,
+            "redirectToURL": ""
+          }
+        }
+      ],
+      "post": []
+    }
+  ]
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%date{yyyy-MM-dd HH:mm:ss.SSS} [%-5p] %c: %m%n
+			</Pattern>
+		</layout>
+	</appender>
+
+	<!-- only gravitee Logs in debug -->
+	<logger name="io.gravitee" level="debug" additivity="false">
+		<appender-ref ref="CONSOLE" />
+	</logger>
+
+	<!-- Root Logger -->
+	<root level="warn">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/7717
**Description**

Test policy with Gateway Testing SDK

- [x] Should open circuit when too many slow calls
- [x] Should open circuit when too many failures
- [x] Should redirect to configured URL when too many failures
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.1`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-circuit-breaker/1.1.1/gravitee-policy-circuit-breaker-1.1.1.zip)
  <!-- Version placeholder end -->
