### PR TITLE
fix: bump dependencies & improve a little the README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,27 @@
 ifdef::env-github[]
 image:https://img.shields.io/static/v1?label=Available%20at&message=Gravitee.io&color=1EC9D2["Gravitee.io", link="https://download.gravitee.io/#graviteeio-apim/plugins/policies/gravitee-policy-circuit-breaker/"]
 image:https://img.shields.io/badge/License-Apache%202.0-blue.svg["License", link="https://github.com/gravitee-io/gravitee-policy-circuit-breaker /blob/master/LICENSE.txt"]
+image:https://img.shields.io/badge/semantic--release-conventional%20commits-e10079?logo=semantic-release["Releases", link="https://github.com/gravitee-io/gravitee-policy-circuit-breaker/releases"]
 image:https://circleci.com/gh/gravitee-io/gravitee-policy-circuit-breaker.svg?style=svg["CircleCI", link="https://circleci.com/gh/gravitee-io/gravitee-policy-circuit-breaker"]
 endif::[]
 
+== Phase
+
+|===
+|onRequest |onResponse
+| X
+|
+|===
+
+== Description
+
 To update
+
+== Compatibility with APIM
+
+|===
+|Plugin version | APIM version
+
+|Up to 1.x                   | All
+|===
+

--- a/pom.xml
+++ b/pom.xml
@@ -35,16 +35,16 @@
     </parent>
 
     <properties>
+        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.5</gravitee-bom.version>
+        <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-gateway-api.version>1.32.2</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.26.1</gravitee-common.version>
-        <resilience4j-circuitbreaker.version>1.3.1</resilience4j-circuitbreaker.version>
+        <resilience4j-circuitbreaker.version>1.7.1</resilience4j-circuitbreaker.version>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <!-- Property used by the publication job in CI-->
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
-        <gravitee-apim-gateway-tests-sdk.version>3.18.0-SNAPSHOT</gravitee-apim-gateway-tests-sdk.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Issue**
na

**Description**
bump dependencies & improve a little the README

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.2-fix-update-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-circuit-breaker/1.1.2-fix-update-dependencies-SNAPSHOT/gravitee-policy-circuit-breaker-1.1.2-fix-update-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
