### PR TITLE
fix: package documentation in zip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     </parent>
 
     <properties>
-        <gravitee-apim-gateway-tests-sdk.version>3.19.0-alpha.1</gravitee-apim-gateway-tests-sdk.version>
+        <gravitee-apim-gateway-tests-sdk.version>3.19.0</gravitee-apim-gateway-tests-sdk.version>
         <gravitee-bom.version>2.6</gravitee-bom.version>
         <gravitee-common.version>1.26.1</gravitee-common.version>
         <gravitee-gateway-api.version>1.42.0</gravitee-gateway-api.version>

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -38,6 +38,14 @@
             <outputDirectory>schemas</outputDirectory>
         </fileSet>
 
+        <fileSet>
+            <directory>${basedir}</directory>
+            <includes>
+                <include>README.adoc</include>
+            </includes>
+            <outputDirectory>docs</outputDirectory>
+        </fileSet>
+
         <!-- Create the empty lib directory in case of no libraries is required -->
         <!-- As there is no maven-assembly-plugin's method do to that, we hack it ourself -->
         <fileSet>


### PR DESCRIPTION

<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.1.4-fix-doc-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-circuit-breaker/1.1.4-fix-doc-SNAPSHOT/gravitee-policy-circuit-breaker-1.1.4-fix-doc-SNAPSHOT.zip)
  <!-- Version placeholder end -->
